### PR TITLE
Odrl

### DIFF
--- a/backend/back/src/main/java/com/ontosov/controllers/OntopController.java
+++ b/backend/back/src/main/java/com/ontosov/controllers/OntopController.java
@@ -23,45 +23,116 @@ public class OntopController {
             String query = ontopService.getPersonDataQuery();
             List<Map<String, String>> results = ontopService.executeQuery(controllerId, taxId, query);
 
-            Map<String, Map<String, Object>> formattedResults = results.stream()
-                    .collect(Collectors.groupingBy(
-                            m -> m.get("source"),
-                            Collectors.collectingAndThen(
-                                    Collectors.toList(),
-                                    list -> {
-                                        Map<String, Object> properties = new HashMap<>();
-                                        list.forEach(item -> {
-                                            String propertyName = item.get("property")
-                                                    .replace("http://schema.org/", "");
-                                            String value = item.get("value");
+            Map<String, Map<String, Object>> formattedResults = new HashMap<>();
 
-                                            // Handle multiple values for same property
-                                            if (properties.containsKey(propertyName)) {
-                                                Object existing = properties.get(propertyName);
-                                                if (existing instanceof List) {
-                                                    // Already a list, just add the new value
-                                                    ((List<String>) existing).add(value);
-                                                } else {
-                                                    // Convert single value to list and add new value
-                                                    List<String> valueList = new ArrayList<>();
-                                                    valueList.add((String) existing);
-                                                    valueList.add(value);
-                                                    properties.put(propertyName, valueList);
-                                                }
-                                            } else {
-                                                // First occurrence of this property
-                                                properties.put(propertyName, value);
-                                            }
-                                        });
-                                        return properties;
-                                    }
-                            )
-                    ));
+            // Group results by source
+            Map<String, List<Map<String, String>>> resultsBySource = results.stream()
+                    .collect(Collectors.groupingBy(m -> m.get("source")));
+
+            for (Map.Entry<String, List<Map<String, String>>> sourceEntry : resultsBySource.entrySet()) {
+                String source = sourceEntry.getKey();
+                List<Map<String, String>> sourceResults = sourceEntry.getValue();
+
+                Map<String, Object> sourceData = new HashMap<>();
+
+                // Separate person data from transactional data
+                Map<String, List<Map<String, String>>> personResults = new HashMap<>();
+                Map<String, List<Map<String, String>>> transactionalResults = new HashMap<>();
+
+                for (Map<String, String> result : sourceResults) {
+                    String entityType = extractEntityType(result.get("entity"));
+                    String parentEntityType = extractEntityType(result.get("parentEntity"));
+                    String entityUri = result.get("entity");
+                    String parentEntityUri = result.get("parentEntity");
+
+                    // Add debugging
+                    // System.out.println("DEBUG - Entity: " + entityUri + " -> Type: " + entityType);
+                    // System.out.println("DEBUG - Parent: " + parentEntityUri + " -> Type: " + parentEntityType);
+                    // System.out.println("DEBUG - Property: " + result.get("property") + " = " + result.get("value"));
+                    // System.out.println("---");
+
+                    // Handle Person properties correctly
+                    if ("Person".equals(entityType) && "Person".equals(parentEntityType)) {
+                        // Genuine Person properties
+                        personResults.computeIfAbsent("Person", k -> new ArrayList<>()).add(result);
+                    } else if ("Person".equals(entityType) && !"Person".equals(parentEntityType)) {
+                        // Person entity appearing as child of Order/MedicalEntity - this is wrong, skip it
+                        System.out.println("SKIPPING: Person property with non-Person parent: " + result.get("property"));
+                        continue;
+                    } else if (!entityUri.equals(parentEntityUri)) {
+                        // Genuine second-level entity (Product in Order)
+                        String parentKey = parentEntityType + ":" + parentEntityUri;
+                        transactionalResults.computeIfAbsent(parentKey, k -> new ArrayList<>()).add(result);
+                    } else {
+                        // First-level entity (Order, MedicalEntity)
+                        String entityKey = entityType + ":" + entityUri;
+                        transactionalResults.computeIfAbsent(entityKey, k -> new ArrayList<>()).add(result);
+                    }
+                }
+
+                // Process person data
+                if (personResults.containsKey("Person")) {
+                    Map<String, Object> personProperties = new HashMap<>();
+                    personResults.get("Person").forEach(item -> {
+                        String propertyName = item.get("property").replace("http://schema.org/", "");
+                        personProperties.put(propertyName, item.get("value"));
+                    });
+                    sourceData.put("Person", personProperties);
+                }
+
+                // Process and merge transactional data
+                Map<String, List<Map<String, Object>>> entitiesByType = new HashMap<>();
+
+                for (Map.Entry<String, List<Map<String, String>>> entry : transactionalResults.entrySet()) {
+                    String key = entry.getKey();
+                    String[] parts = key.split(":", 2);
+                    String entityType = parts[0];
+                    String entityId = parts[1];
+
+                    // Create entity with merged properties
+                    Map<String, Object> entity = new HashMap<>();
+                    entity.put("entityId", entityId);
+
+                    Map<String, String> properties = new HashMap<>();
+                    entry.getValue().forEach(item -> {
+                        String propertyName = item.get("property").replace("http://schema.org/", "");
+                        properties.put(propertyName, item.get("value"));
+                    });
+                    entity.put("properties", properties);
+
+                    entitiesByType.computeIfAbsent(entityType, k -> new ArrayList<>()).add(entity);
+                }
+
+                // Add to source data
+                entitiesByType.forEach((entityType, entities) -> {
+                    sourceData.put(entityType, entities);
+                });
+
+                formattedResults.put(source, sourceData);
+            }
 
             return ResponseEntity.ok(formattedResults);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.internalServerError().build();
         }
+    }
+
+    private String extractEntityType(String entityUri) {
+        if (entityUri.contains("#")) {
+            String afterHash = entityUri.substring(entityUri.lastIndexOf('#') + 1);
+            if (afterHash.contains("/")) {
+                return afterHash.substring(0, afterHash.indexOf("/"));
+            }
+            return afterHash;
+        } else if (entityUri.contains("/")) {
+            String[] parts = entityUri.split("/");
+            for (int i = parts.length - 1; i >= 0; i--) {
+                if (!parts[i].matches("\\d+")) { // Skip numeric IDs
+                    return parts[i];
+                }
+            }
+        }
+        return "Unknown";
     }
 }

--- a/backend/back/src/main/resources/ontop/controllers/8/database_configs.properties
+++ b/backend/back/src/main/resources/ontop/controllers/8/database_configs.properties
@@ -1,18 +1,18 @@
 #Database configurations for controller 8
-#Mon Sep 22 16:13:41 CEST 2025
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.jdbc.driver=com.mysql.cj.jdbc.Driver
+#Tue Sep 23 19:23:31 CEST 2025
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.jdbc.password=mysql
 db.fe3eab36-288e-4a59-b489-e1d2e26a9493.jdbc.url=jdbc\:postgresql\://localhost\:5432/AControllerDB
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.jdbc.password=mysql
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.jdbc.url=jdbc\:mysql\://localhost\:3306/health_research_center
-db.fe3eab36-288e-4a59-b489-e1d2e26a9493.name=AControllerDB
-db.fe3eab36-288e-4a59-b489-e1d2e26a9493.jdbc.driver=org.postgresql.Driver
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.name=health_research_center
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.host=localhost
 db.fe3eab36-288e-4a59-b489-e1d2e26a9493.jdbc.user=postgres
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.type=mysql
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.name=health_research_center
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.host=localhost
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.port=3306
+db.fe3eab36-288e-4a59-b489-e1d2e26a9493.jdbc.driver=org.postgresql.Driver
+db.fe3eab36-288e-4a59-b489-e1d2e26a9493.name=AControllerDB
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.type=mysql
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.jdbc.driver=com.mysql.cj.jdbc.Driver
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.port=3306
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.jdbc.url=jdbc\:mysql\://localhost\:3306/health_research_center
 db.fe3eab36-288e-4a59-b489-e1d2e26a9493.type=postgresql
-db.cfbb5796-667e-49f0-99f0-75fb8642221d.jdbc.user=root
+db.dfe0f3e4-8542-4244-b288-597c5ad80353.jdbc.user=root
 db.fe3eab36-288e-4a59-b489-e1d2e26a9493.port=5432
 db.fe3eab36-288e-4a59-b489-e1d2e26a9493.jdbc.password=postgres
 db.fe3eab36-288e-4a59-b489-e1d2e26a9493.host=localhost

--- a/backend/back/src/main/resources/ontop/controllers/8/db_AControllerDB_mappings.obda
+++ b/backend/back/src/main/resources/ontop/controllers/8/db_AControllerDB_mappings.obda
@@ -9,8 +9,8 @@ target  :Order/{order_id} a schema:Order ; schema:orderDate {order_date} .
 source  SELECT order_id, order_date FROM order_history
 
 mappingId user_profiles_mapping
-target  :Person/{user_id} a schema:Person ; schema:givenName {name} ; schema:taxID {tax_id} ; schema:email {email} .
-source  SELECT user_id, name, tax_id, email FROM user_profiles
+target  :Person/{user_id} a schema:Person ; schema:givenName {name} ; schema:taxID {tax_id} ; schema:email {email} ; schema:telephone {phone_number} .
+source  SELECT user_id, name, tax_id, email, phone_number FROM user_profiles
 
 mappingId store_locations_mapping
 target  :Store/{store_id} a schema:Store ; schema:name {store_name} ; schema:address {city} .

--- a/backend/back/src/main/resources/ontop/controllers/8/db_health_research_center_mappings.obda
+++ b/backend/back/src/main/resources/ontop/controllers/8/db_health_research_center_mappings.obda
@@ -4,36 +4,16 @@ schema: http://schema.org/
 xsd:    http://www.w3.org/2001/XMLSchema#
 
 [MappingDeclaration] @collection [[
-mappingId patients_Person_tax_identifier_Mapping
-target :Resource/{patient_id} a schema:Person . :Resource/{patient_id} schema:taxID "{tax_identifier}"^^xsd:string .
-source SELECT patient_id, tax_identifier FROM patients
+mappingId medical_records_mapping
+target  :MedicalEntity/{record_id} a schema:MedicalEntity ; schema:healthCondition {health_condition} ; schema:dateReceived {date} .
+source  SELECT record_id, health_condition, date FROM medical_records
 
-mappingId patients_Person_given_name_Mapping
-target :Resource/{patient_id} a schema:Person . :Resource/{patient_id} schema:givenName "{given_name}"^^xsd:string .
-source SELECT patient_id, given_name FROM patients
+mappingId patients_mapping
+target  :Person/{patient_id} a schema:Person ; schema:taxID {tax_identifier} ; schema:givenName {given_name} ; schema:familyName {family_name} ; schema:birthDate {birth_date} .
+source  SELECT patient_id, tax_identifier, given_name, family_name, birth_date FROM patients
 
-mappingId patients_Person_family_name_Mapping
-target :Resource/{patient_id} a schema:Person . :Resource/{patient_id} schema:familyName "{family_name}"^^xsd:string .
-source SELECT patient_id, family_name FROM patients
-
-mappingId patients_Person_email_Mapping
-target :Resource/{patient_id} a schema:Person . :Resource/{patient_id} schema:email "{email}"^^xsd:string .
-source SELECT patient_id, email FROM patients
-
-mappingId patients_Person_birth_date_Mapping
-target :Resource/{patient_id} a schema:Person . :Resource/{patient_id} schema:birthDate "{birth_date}"^^xsd:string .
-source SELECT patient_id, birth_date FROM patients
-
-mappingId medical_records_Patient_health_condition_Mapping
-target :Resource/{record_id} a schema:Patient . :Resource/{record_id} schema:healthCondition "{health_condition}"^^xsd:string .
-source SELECT record_id, health_condition FROM medical_records
-
-mappingId medical_records_Patient_treatment_Mapping
-target :Resource/{record_id} a schema:Patient . :Resource/{record_id} schema:drug "{treatment}"^^xsd:string .
-source SELECT record_id, treatment FROM medical_records
-
-mappingId medical_records_Event_date_Mapping
-target :Resource/{record_id} a schema:Event . :Resource/{record_id} schema:startDate "{date}"^^xsd:string .
-source SELECT record_id, date FROM medical_records
+mappingId medical_records_patients_rel
+target  :MedicalEntity/{record_id} schema:about :Person/{patient_id} .
+source  SELECT s.record_id, t.patient_id FROM medical_records s JOIN patients t ON s.patient_id = t.patient_id
 
 ]]


### PR DESCRIPTION
feat: implement entity-aware data federation for granular privacy control

- Replace comma-separated property aggregation with entity-preserving SPARQL queries
- Add support for dual privacy models: property-level (Person) and entity-level (Orders)
- Merge second-level entities (Products) into parent entities (Orders) 
- Update frontend to display personal info and transactional data with proper separation